### PR TITLE
fix: aligner la dépendance hapiclient sur le fork akki-team

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,15 @@
     "sylius/sylius": "^2.0",
     "payum/core": "^1.7",
     "payum/payum-bundle": "^2.5",
-    "slimpay/hapiclient": "dev-master"
+    "akki-team/hapiclient": "^1.0"
   },
   "require-dev": {
     "php-http/guzzle7-adapter": "^1.0"
   },
   "repositories": {
-    "slimpayHapiclient": {
+    "akkiHapiclient": {
       "type": "vcs",
-      "url": "https://github.com/ichiabdelkrim/hapiclient-php"
+      "url": "https://github.com/akki-team/hapiclient-php.git"
     }
   },
   "license": "MIT",


### PR DESCRIPTION
Suite du portage Sylius 2 (mergé dans `2.0`). Réalignement de la dépendance HapiClient.

## Problème
Le plugin requérait `slimpay/hapiclient` (fork `ichiabdelkrim/hapiclient-php`), alors que `uniqueheritage114` utilise `akki-team/hapiclient`. Les deux exposent le namespace `HapiClient\` → **risque de conflit d'autoload** en Sylius 2.

## Changement
- `require` : `slimpay/hapiclient:dev-master` → **`akki-team/hapiclient:^1.0`** (fork maintenu, déjà `php ^8.0` + `guzzle >=7.10`).
- `repositories` : vcs `ichiabdelkrim/hapiclient-php` → `akki-team/hapiclient-php`.
- Aucun changement de code (namespace `HapiClient\` inchangé).

## Validation
Résolution composer OK : `akki-team/hapiclient v1.1` + `guzzlehttp/guzzle 7.12.3` + `payum/core 1.7.7` + `sylius/sylius v2.2.6`, sans conflit. Les 9 classes `HapiClient\` utilisées par le plugin sont présentes dans le fork akki-team.